### PR TITLE
Fixing a few Py2 -> Py3 issues

### DIFF
--- a/gomill/gtp_engine.py
+++ b/gomill/gtp_engine.py
@@ -157,10 +157,7 @@ def _clean_response(response):
     """Clean up a proposed response."""
     if response is None:
         return ""
-    if isinstance(response, unicode):
-        s = response.encode("utf-8")
-    else:
-        s = str(response)
+    s = str(response)
     s = s.rstrip()
     s = s.replace("\n\n", "\n.\n")
     s = _remove_response_controls_re.sub("", s)

--- a/gomill/gtp_games.py
+++ b/gomill/gtp_games.py
@@ -91,7 +91,7 @@ class Game_result(gameplay.Result):
         If a value is already set (not None), this method doesn't change it.
 
         """
-        for colour, cpu_time in cpu_times.iteritems():
+        for colour, cpu_time in cpu_times.items():
             if self.cpu_times[self.players[colour]] is not None:
                 continue
             self.cpu_times[self.players[colour]] = cpu_time

--- a/gomill/utils.py
+++ b/gomill/utils.py
@@ -58,14 +58,17 @@ def sanitise_utf8(s):
     """
     if s is None:
         return None
-    try:
-        s.decode("utf-8")
-    except UnicodeDecodeError:
-        return (s.decode("utf-8", 'replace')
-                .replace(u"\ufffd", u"?")
-                .encode("utf-8"))
-    else:
+    elif type(s) is str:
         return s
+    else:
+        try:
+            s.decode("utf-8")
+        except UnicodeDecodeError:
+            return (s.decode("utf-8", 'replace')
+                    .replace(u"\ufffd", u"?")
+                    .encode("utf-8"))
+        else:
+            return s
 
 def ensure_dir(pathname):
     """Create a directory, unless it already exists."""


### PR DESCRIPTION
- All strings are unicode now, so had to tweak IO routines.
- SIGPIPE issue is supposedly fixed in Py3.
- iteritem() no longer exists.  Just use item().
- map now returns an iterator instead of a list, so we need to
explicitly call list().